### PR TITLE
Client- and server-side http api validation example

### DIFF
--- a/x-pack/plugins/infra/common/http_api/health_snapshot_api.ts
+++ b/x-pack/plugins/infra/common/http_api/health_snapshot_api.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import * as runtimeTypes from 'io-ts';
+
+export const healthSnapshotApiPath = '/api/infra/health-snapshot';
+
+export const healthSnapshotApiRequestPayloadType = runtimeTypes.type({
+  sourceId: runtimeTypes.string,
+  time: runtimeTypes.number,
+});
+
+export const healthStatusType = runtimeTypes.keyof({
+  healthy: null,
+  unhealthy: null,
+});
+
+export const healthCheckType = runtimeTypes.type({
+  id: runtimeTypes.string,
+  health: healthStatusType,
+  time: runtimeTypes.number,
+});
+
+export type HealthCheck = runtimeTypes.TypeOf<typeof healthCheckType>;
+
+// export interface HealthCheck {
+//   id: string;
+//   health: 'healthy' | 'unhealthy';
+//   time: number;
+// }
+
+export const healthSnapshotApiResponsePayloadType = runtimeTypes.type({
+  params: healthSnapshotApiRequestPayloadType,
+  data: runtimeTypes.type({
+    healthSnapshot: runtimeTypes.array(healthCheckType),
+  }),
+});

--- a/x-pack/plugins/infra/public/containers/health_snapshot.ts
+++ b/x-pack/plugins/infra/public/containers/health_snapshot.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { failure } from 'io-ts/lib/PathReporter';
+import { useState, useEffect } from 'react';
+
+import {
+  HealthCheck,
+  healthSnapshotApiPath,
+  healthSnapshotApiRequestPayloadType,
+  healthSnapshotApiResponsePayloadType,
+} from '../../common/http_api';
+
+export const useHealthSnapshot = ({ sourceId, time }: { sourceId: string; time: number }) => {
+  const [healthSnapshot, setHealthSnapshot] = useState<HealthCheck[]>([]);
+
+  useEffect(
+    () => {
+      fetchHealthSnapshot(sourceId, time)
+        .then(result =>
+          healthSnapshotApiResponsePayloadType.decode(result.json()).getOrElseL(errors => {
+            throw new Error(failure(errors).join('\n'));
+          })
+        )
+        .then(decodedResult => setHealthSnapshot(decodedResult.data.healthSnapshot));
+    },
+    [sourceId, time]
+  );
+
+  return {
+    isAllHealthy: healthSnapshot.every(healthCheck => healthCheck.health === 'healthy'),
+  };
+};
+
+const fetchHealthSnapshot = (sourceId: string, time: number) =>
+  fetch(healthSnapshotApiPath, {
+    method: 'POST',
+    body: JSON.stringify(
+      healthSnapshotApiRequestPayloadType.encode({
+        sourceId,
+        time,
+      })
+    ),
+  });

--- a/x-pack/plugins/infra/server/http_api_example/health_snapshot.ts
+++ b/x-pack/plugins/infra/server/http_api_example/health_snapshot.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+import { failure } from 'io-ts/lib/PathReporter';
+
+import { InternalCoreSetup } from 'src/core/server';
+import {
+  HealthCheck,
+  healthSnapshotApiPath,
+  healthSnapshotApiRequestPayloadType,
+  healthSnapshotApiResponsePayloadType,
+} from '../../common/http_api';
+
+export const registerRoutes = (core: InternalCoreSetup) => {
+  const { server } = core.http;
+
+  server.route({
+    path: healthSnapshotApiPath,
+    method: 'POST',
+    async handler(request, response) {
+      const payload = healthSnapshotApiRequestPayloadType
+        .decode(request.payload)
+        .getOrElseL(errors => {
+          throw new Error(failure(errors).join('\n'));
+        });
+
+      const result = await getHealthSnapshot(payload.sourceId, payload.time);
+
+      return response.response(
+        healthSnapshotApiResponsePayloadType.encode({
+          params: payload,
+          data: {
+            healthSnapshot: result,
+          },
+        })
+      );
+    },
+  });
+};
+
+const getHealthSnapshot = async (sourceId: string, time: number): Promise<HealthCheck[]> =>
+  sourceId === 'default'
+    ? [
+        {
+          id: 'check1',
+          health: 'healthy',
+          time,
+        },
+        {
+          id: 'check2',
+          health: 'unhealthy',
+          time,
+        },
+      ]
+    : [];

--- a/x-pack/plugins/infra/server/http_api_example/index.ts
+++ b/x-pack/plugins/infra/server/http_api_example/index.ts
@@ -4,6 +4,4 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-export * from './health_snapshot_api';
-export * from './search_results_api';
-export * from './search_summary_api';
+export { registerRoutes } from './health_snapshot';


### PR DESCRIPTION
This is an example for a HTTP API convention that is well-typed from end to end.