### PR TITLE
Add retrieveResults parameter to get search request results instead of status during polling

### DIFF
--- a/src/plugins/data/common/search/types.ts
+++ b/src/plugins/data/common/search/types.ts
@@ -154,6 +154,13 @@ export interface ISearchOptions {
   isRestore?: boolean;
 
   /**
+   * By default, when polling, we don't retrieve the results of the search request (until it is complete). (For async
+   * search, this is the difference between calling _async_search/{id} and _async_search/status/{id}.) setting this to
+   * `true` will request the search results, regardless of whether or not the search is complete.
+   */
+  retrieveResults?: boolean;
+
+  /**
    * Represents a meta-information about a Kibana entity intitating a saerch request.
    */
   executionContext?: KibanaExecutionContext;
@@ -182,5 +189,6 @@ export type ISearchOptionsSerializable = Pick<
   | 'isStored'
   | 'isSearchStored'
   | 'isRestore'
+  | 'retrieveResults'
   | 'executionContext'
 >;

--- a/src/plugins/data/public/search/search_interceptor/search_interceptor.ts
+++ b/src/plugins/data/public/search/search_interceptor/search_interceptor.ts
@@ -257,6 +257,8 @@ export class SearchInterceptor {
 
     if (combined.sessionId !== undefined) serializableOptions.sessionId = combined.sessionId;
     if (combined.isRestore !== undefined) serializableOptions.isRestore = combined.isRestore;
+    if (combined.retrieveResults !== undefined)
+      serializableOptions.retrieveResults = combined.retrieveResults;
     if (combined.legacyHitsTotal !== undefined)
       serializableOptions.legacyHitsTotal = combined.legacyHitsTotal;
     if (combined.strategy !== undefined) serializableOptions.strategy = combined.strategy;

--- a/src/plugins/data/server/search/routes/search.ts
+++ b/src/plugins/data/server/search/routes/search.ts
@@ -36,6 +36,7 @@ export function registerSearchRoute(router: DataPluginRouter): void {
                 sessionId: schema.maybe(schema.string()),
                 isStored: schema.maybe(schema.boolean()),
                 isRestore: schema.maybe(schema.boolean()),
+                retrieveResults: schema.maybe(schema.boolean()),
               },
               { unknowns: 'allow' }
             ),
@@ -48,6 +49,7 @@ export function registerSearchRoute(router: DataPluginRouter): void {
           sessionId,
           isStored,
           isRestore,
+          retrieveResults,
           ...searchRequest
         } = request.body;
         const { strategy, id } = request.params;
@@ -65,6 +67,7 @@ export function registerSearchRoute(router: DataPluginRouter): void {
                 sessionId,
                 isStored,
                 isRestore,
+                retrieveResults,
               }
             )
             .pipe(first())

--- a/src/plugins/data/server/search/strategies/ese_search/ese_search_strategy.ts
+++ b/src/plugins/data/server/search/strategies/ese_search/ese_search_strategy.ts
@@ -73,9 +73,11 @@ export const enhancedEsSearchStrategyProvider = (
     options: IAsyncSearchOptions,
     { esClient }: SearchStrategyDependencies
   ) {
-    // First, request the status of the async search, and return the status if incomplete
-    const status = await asyncSearchStatus({ id, ...request }, options, { esClient });
-    if (isRunningResponse(status)) return status;
+    if (!options.retrieveResults) {
+      // First, request the status of the async search, and return the status if incomplete
+      const status = await asyncSearchStatus({ id, ...request }, options, { esClient });
+      if (isRunningResponse(status)) return status;
+    }
 
     // Then, if the search is complete, request & return the final results
     const client = useInternalUser ? esClient.asInternalUser : esClient.asCurrentUser;


### PR DESCRIPTION
## Summary

Adds `retrieveResults` parameter for the backport.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
